### PR TITLE
Ch 8: Error Handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ name = "email-newsletter"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "anyhow",
  "chrono",
  "claims",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "sqlx",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ secrecy = { version = "0.8", features = ["serde"] }
 tracing-actix-web = "0.7"
 validator = "0.16"
 rand = { version = "0.8", features = ["std_rng"] }
+thiserror = "1"
 
 [dependencies.sqlx]
 version = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing-actix-web = "0.7"
 validator = "0.16"
 rand = { version = "0.8", features = ["std_rng"] }
 thiserror = "1"
+anyhow = "1"
 
 [dependencies.sqlx]
 version = "0.6.3"

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -1,0 +1,13 @@
+/// Iterates over a chain of errors via the `source` method and prints the error with its cause
+pub fn error_chain_fmt(
+    error: &impl std::error::Error,
+    formatter: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    writeln!(formatter, "{}\n", error)?;
+    let mut current = error.source();
+    while let Some(cause) = current {
+        writeln!(formatter, "Caused by:\n\t{}", cause)?;
+        current = cause.source();
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod email_client;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;
+mod error_handling;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod configuration;
 pub mod domain;
 pub mod email_client;
+mod error_handling;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;
-mod error_handling;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -40,21 +40,18 @@ pub async fn subscribe(
     let mut transaction = connection_pool
         .begin()
         .await
-        .map_err(|e| SubscribeError::PoolError(e))?;
+        .map_err(SubscribeError::PoolError)?;
 
     let subscriber_id = insert_subscriber(&new_subscriber, &mut transaction)
         .await
-        .map_err(|e| SubscribeError::InsertSubscriberError(e))?;
+        .map_err(SubscribeError::InsertSubscriberError)?;
     let token = generate_subscription_token();
-    // store_token returns a StoreTokenError, but since we've implemented ResponseError on StoreTokenError,
-    // we get `From<StoreTokenError> for actix_web::Error` for free, so the `?` operator can implicitly
-    // convert our returned StoreTokenError into the actix_web::Error that this handler returns
     store_token(&mut transaction, subscriber_id, &token).await?;
 
     transaction
         .commit()
         .await
-        .map_err(|e| SubscribeError::TransactionCommitError(e))?;
+        .map_err(SubscribeError::TransactionCommitError)?;
 
     send_confirmation_email(
         &email_client,

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -157,7 +157,6 @@ pub async fn store_token(
     Ok(())
 }
 
-#[derive(Debug)]
 pub struct StoreTokenError(sqlx::Error);
 
 impl std::fmt::Display for StoreTokenError {
@@ -174,7 +173,34 @@ impl std::fmt::Display for StoreTokenError {
     }
 }
 
+impl std::fmt::Debug for StoreTokenError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
+    }
+}
+
 impl ResponseError for StoreTokenError {}
+
+impl std::error::Error for StoreTokenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        // compiler can implicitly cast `&sqlx::Error` into `&dyn Error`
+        Some(&self.0)
+    }
+}
+
+/// Iterates over a chain of errors via the `source` method and prints the error with its cause
+fn error_chain_fmt(
+    error: &impl std::error::Error,
+    formatter: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    writeln!(formatter, "{}\n", error)?;
+    let mut current = error.source();
+    while let Some(cause) = current {
+        writeln!(formatter, "Caused by:\n\t{}", cause)?;
+        current = cause.source();
+    }
+    Ok(())
+}
 
 /// Generate a random 25-character subscription token
 fn generate_subscription_token() -> String {

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,10 +1,10 @@
 use std::fmt::Formatter;
 
 use actix_web::http::StatusCode;
-use actix_web::{HttpResponse, ResponseError, web};
+use actix_web::{web, HttpResponse, ResponseError};
 use anyhow::Context;
 use rand::distributions::Alphanumeric;
-use rand::{Rng, thread_rng};
+use rand::{thread_rng, Rng};
 use sqlx::types::chrono::Utc;
 use sqlx::types::uuid;
 use sqlx::{PgPool, Postgres, Transaction};

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,5 +1,6 @@
 use std::fmt::Formatter;
 
+use actix_web::http::StatusCode;
 use actix_web::{web, HttpResponse, ResponseError};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -31,46 +32,81 @@ pub async fn subscribe(
     connection_pool: web::Data<PgPool>,
     email_client: web::Data<EmailClient>,
     application_base_url: web::Data<ApplicationBaseUrl>,
-) -> Result<HttpResponse, actix_web::Error> {
-    let new_subscriber = match form.0.try_into() {
-        Ok(new_subscriber) => new_subscriber,
-        Err(_) => return Ok(HttpResponse::BadRequest().finish()),
-    };
+) -> Result<HttpResponse, SubscribeError> {
+    let new_subscriber = form.0.try_into()?;
 
     // creating an sqlx Transaction struct by calling begin on the pool
     // this struct implements the Executor trait, so it can be used instead of a reference to the connection pool
-    let mut transaction = match connection_pool.begin().await {
-        Ok(transaction) => transaction,
-        Err(_) => return Ok(HttpResponse::InternalServerError().finish()),
-    };
+    let mut transaction = connection_pool.begin().await?;
 
-    let subscriber_id = match insert_subscriber(&new_subscriber, &mut transaction).await {
-        Ok(subscriber_id) => subscriber_id,
-        Err(_) => return Ok(HttpResponse::InternalServerError().finish()),
-    };
+    let subscriber_id = insert_subscriber(&new_subscriber, &mut transaction).await?;
     let token = generate_subscription_token();
     // store_token returns a StoreTokenError, but since we've implemented ResponseError on StoreTokenError,
     // we get `From<StoreTokenError> for actix_web::Error` for free, so the `?` operator can implicitly
     // convert our returned StoreTokenError into the actix_web::Error that this handler returns
     store_token(&mut transaction, subscriber_id, &token).await?;
 
-    if transaction.commit().await.is_err() {
-        return Ok(HttpResponse::InternalServerError().finish());
-    }
+    transaction.commit().await?;
 
-    if send_confirmation_email(
+    send_confirmation_email(
         &email_client,
         new_subscriber,
         &application_base_url.0,
         &token,
     )
-    .await
-    .is_err()
-    {
-        return Ok(HttpResponse::InternalServerError().finish());
-    }
+    .await?;
 
     Ok(HttpResponse::Ok().finish())
+}
+
+/// An error type that owns HTTP-related logic
+#[derive(Debug)]
+pub enum SubscribeError {
+    ValidationError(String),
+    DatabaseError(sqlx::Error),
+    StoreTokenError(StoreTokenError),
+    SendEmailError(reqwest::Error),
+}
+
+impl std::fmt::Display for SubscribeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Failed to create new subscriber.")
+    }
+}
+
+impl std::error::Error for SubscribeError {}
+
+impl ResponseError for SubscribeError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            SubscribeError::ValidationError(_) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl From<reqwest::Error> for SubscribeError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::SendEmailError(e)
+    }
+}
+
+impl From<sqlx::Error> for SubscribeError {
+    fn from(e: sqlx::Error) -> Self {
+        Self::DatabaseError(e)
+    }
+}
+
+impl From<StoreTokenError> for SubscribeError {
+    fn from(e: StoreTokenError) -> Self {
+        Self::StoreTokenError(e)
+    }
+}
+
+impl From<String> for SubscribeError {
+    fn from(e: String) -> Self {
+        Self::ValidationError(e)
+    }
 }
 
 #[tracing::instrument(
@@ -178,8 +214,6 @@ impl std::fmt::Debug for StoreTokenError {
         error_chain_fmt(self, f)
     }
 }
-
-impl ResponseError for StoreTokenError {}
 
 impl std::error::Error for StoreTokenError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {

--- a/src/routes/subscriptions_confirm.rs
+++ b/src/routes/subscriptions_confirm.rs
@@ -1,6 +1,12 @@
-use actix_web::{web, HttpResponse};
+use std::fmt::Formatter;
+
+use actix_web::http::StatusCode;
+use actix_web::{web, HttpResponse, ResponseError};
+use anyhow::Context;
 use sqlx::PgPool;
 use uuid::Uuid;
+
+use crate::error_handling;
 
 #[derive(serde::Deserialize)]
 pub struct Parameters {
@@ -12,7 +18,7 @@ pub struct Parameters {
 pub async fn confirm(
     parameters: web::Query<Parameters>,
     connection_pool: web::Data<PgPool>,
-) -> HttpResponse {
+) -> Result<HttpResponse, ConfirmSubscriberError> {
     // using web::Query<Parameters> tells actix that the parameters are mandatory; this handler is only called if
     // those query parameters extract; otherwise, returns a 400
     /* My first implementation, before reading the book, was the use a single UPDAte query.
@@ -27,26 +33,38 @@ pub async fn confirm(
         parameters.subscription_token
     )
      */
-    let subscriber_id = match get_subscriber_id_from_token(
-        &parameters.subscription_token,
-        &connection_pool,
-    )
-    .await
-    {
-        Ok(option) => match option {
-            Some(id) => id,
-            // token does not exist
-            None => return HttpResponse::Unauthorized().finish(),
-        },
-        Err(_) => return HttpResponse::InternalServerError().finish(),
-    };
-    if confirm_subscriber(subscriber_id, &connection_pool)
+    let subscriber_id =
+        get_subscriber_id_from_token(&parameters.subscription_token, &connection_pool)
+            .await
+            .context("Failed to get subscriber ID from token")?
+            .ok_or(ConfirmSubscriberError::UnknownToken)?;
+    confirm_subscriber(subscriber_id, &connection_pool)
         .await
-        .is_err()
-    {
-        return HttpResponse::InternalServerError().finish();
+        .context("Failed to confirm subscriber.")?;
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[derive(thiserror::Error)]
+pub enum ConfirmSubscriberError {
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+    #[error("There is no subscriber associated with the provided token.")]
+    UnknownToken,
+}
+
+impl std::fmt::Debug for ConfirmSubscriberError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        error_handling::error_chain_fmt(&self, f)
     }
-    HttpResponse::Ok().finish()
+}
+
+impl ResponseError for ConfirmSubscriberError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ConfirmSubscriberError::UnknownToken => StatusCode::UNAUTHORIZED,
+            ConfirmSubscriberError::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
 }
 
 #[tracing::instrument(
@@ -64,11 +82,7 @@ pub async fn confirm_subscriber(
         subscriber_id
     )
     .execute(connection_pool)
-    .await
-    .map_err(|e| {
-        tracing::error!("Failed to execute query: {:?}", e);
-        e
-    })?;
+    .await?;
     Ok(())
 }
 
@@ -85,10 +99,6 @@ pub async fn get_subscriber_id_from_token(
         subscription_token,
     )
     .fetch_optional(connection_pool)
-    .await
-    .map_err(|e| {
-        tracing::error!("Failed to execute query: {:?}", e);
-        e
-    })?;
+    .await?;
     Ok(result.map(|r| r.subscriber_id))
 }


### PR DESCRIPTION
There's a lot of cool stuff in this chapter, but the work in a86a9e5f2b579c46e2183892850150b52e3f46ce particularly caught my interest. This is where we implement `SubscribeError`, an enum that includes lots of different error types. It includes a custom `ResponseError.status_code` implementation that returns a `400` for validation errors, and `500`s for everything else. It also allows us to greatly simplify the `subscribe` handler. Instead of a whole bunch of `match` statements or `if some_func().is_err() {return 500}`, we just call the function and use the `?` operator. Each function might raise a different type of error (validation, database-related error, http error from reqwest, etc.). But we implemented `From<T> for SubscribeError` for all those types, and `SubscribeError` implements `ResponseError`, so we can just bubble any of those errors up with `?` and actix handles generating the response for us with the proper status code. Really cool.

## Update

Having come a bit further in the chapter, I now have this error handling setup:
```rs
// this is the request handler we're working on writing better error handling for
pub async fn subscribe(
    form: web::Form<FormData>,
    connection_pool: web::Data<PgPool>,
    email_client: web::Data<EmailClient>,
    application_base_url: web::Data<ApplicationBaseUrl>,
) -> Result<HttpResponse, SubscribeError> {
    let new_subscriber = form.0.try_into()?;

    let mut transaction = connection_pool
        .begin()
        .await
        .map_err(SubscribeError::PoolError)?;

    let subscriber_id = insert_subscriber(&new_subscriber, &mut transaction)
        .await
        .map_err(SubscribeError::InsertSubscriberError)?;
    let token = generate_subscription_token();
    store_token(&mut transaction, subscriber_id, &token).await?;

    transaction
        .commit()
        .await
        .map_err(SubscribeError::TransactionCommitError)?;

    send_confirmation_email(
        &email_client,
        new_subscriber,
        &application_base_url.0,
        &token,
    )
    .await?;

    Ok(HttpResponse::Ok().finish())
}

/// An error type that owns HTTP-related logic
pub enum SubscribeError {
    ValidationError(String),
    StoreTokenError(StoreTokenError),
    SendEmailError(reqwest::Error),
    // database-related errors
    PoolError(sqlx::Error),
    InsertSubscriberError(sqlx::Error),
    TransactionCommitError(sqlx::Error),
}

impl std::fmt::Display for SubscribeError {
    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
        match self {
            SubscribeError::ValidationError(e) => write!(f, "{}", e),
            SubscribeError::StoreTokenError(_) => {
                write!(f, "Failed to store confirmation token for new subscriber")
            }
            SubscribeError::SendEmailError(_) => write!(f, "Failed to send confirmation email"),
            SubscribeError::PoolError(_) => {
                write!(f, "Failed to acquire a Postgres connection from the pool")
            }
            SubscribeError::InsertSubscriberError(_) => {
                write!(f, "Failed to insert new subscriber in the database")
            }
            SubscribeError::TransactionCommitError(_) => write!(
                f,
                "Failed to commit SQL transaction to store new subscriber"
            ),
        }
    }
}

impl std::fmt::Debug for SubscribeError {
    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
        error_chain_fmt(self, f)
    }
}

impl std::error::Error for SubscribeError {
    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
        match self {
            // since &str doesn't implement `Error`, we will consider it the root cause
            SubscribeError::ValidationError(_) => None, // no source == this is the root cause
            SubscribeError::StoreTokenError(e) => Some(e),
            SubscribeError::SendEmailError(e) => Some(e),
            SubscribeError::PoolError(e) => Some(e),
            SubscribeError::InsertSubscriberError(e) => Some(e),
            SubscribeError::TransactionCommitError(e) => Some(e),
        }
    }
}

impl ResponseError for SubscribeError {
    fn status_code(&self) -> StatusCode {
        match self {
            SubscribeError::ValidationError(_) => StatusCode::BAD_REQUEST,
            _ => StatusCode::INTERNAL_SERVER_ERROR,
        }
    }
}

impl From<reqwest::Error> for SubscribeError {
    fn from(e: reqwest::Error) -> Self {
        Self::SendEmailError(e)
    }
}

impl From<StoreTokenError> for SubscribeError {
    fn from(e: StoreTokenError) -> Self {
        Self::StoreTokenError(e)
    }
}

impl From<String> for SubscribeError {
    fn from(e: String) -> Self {
        Self::ValidationError(e)
    }
}
```

It's a lot of code, so I'm going to summarize what's going on (primarily for my own benefit, to help it sink in). The goal of all this is to have an ergonomic place to define error handling in such a way that actix can use the errors we return to construct responses. That means, at the very least, we need an error type that implements `ResponseError`. We have that in `SubscribeError`. Note that our `subscribe` view returns a result with `SubscribeError` as its error type. We can only do this because we implement `ResponseError`. If we didn't , the trait bound introduced here `...route("/subscriptions", web::post().to(subscribe))` (specifically in `to`) would not be satisfied.

`ResponseError` requires that we implement `Debug` and `Display`. We could have just derived `Debug`, but our custom implementation is a bit better, by displaying (i.e., using `writeln!`, therefore relying on the `Display` trait) the source of each error in the chain (through the `source` method, which is implemented by the `std::error::Error` trait).

Our implementation of the `Display` trait, meanwhile, handles generating our user-facing error message for each error type. With these in place, we can implement `ResponseError`, as it has default implementations for its own methods, but we override the `status_code` method to return a `400` for validation errors (default implementation returns `500` for everything).

The final piece is to simply implement `From<T> for SubscribeError` for all the error types that might be returned throughout the entire `subscribe` handler. This is what allows us to do things like `send_confirmation_email(...).await?;` inside `subscribe`. `send_confirmation_email` can return a `reqwest::Error`, but since we have implemented `From<reqwest::Error> for SubscribeError`, we can use the `?` inside `subscribe` to implicitly convert the returned `reqwest::Error` into the `SubscribeError` returned by our request handler.

And one final piece: note that we haven't implemented `From<sqlx::Error> for SubscribeError`. This is because we return a few different sqlx errors within `subscribe`, and the error type alone is not enough to disambiguate what enum member we should convert to. That's why we use `map_err` within `subscribe` to handle those conversions explicitly.

So in summary: we have a request handler that can encounter lots of different error types through its numerous calls. To deal with this, we define our own custom error type, define how that error type should display its information (through `Display`, `Debug`, and `ResponseError` traits) and define how we convert from the different errors we might encounter to our custom type (through `From` traits and `map_err` usage). And then we're all set!

## Refactoring to use `thiserror`

The `From`, `source`, and `Display` implementations seen above are a lot of boilerplate. Turns out the `thiserror` crate can handle a lot of that:
```rs
/// An error type that owns HTTP-related logic
#[derive(thiserror::Error)]
pub enum SubscribeError {
    #[error("{0}")]
    ValidationError(String),
    #[error("Failed to store the confirmation token for a new subscriber.")]
    StoreTokenError(#[from] StoreTokenError),
    #[error("Failed to send a confirmation email")]
    SendEmailError(#[from] reqwest::Error),
    // database-related errors
    #[error("Failed to acquire a Postgres connection from the pool.")]
    PoolError(#[source] sqlx::Error),
    #[error("Failed to insert a new subscribe in the database.")]
    InsertSubscriberError(#[source] sqlx::Error),
    #[error("Failed to commit SQL transaction to store a new subscriber.")]
    TransactionCommitError(#[source] sqlx::Error),
}

impl std::fmt::Debug for SubscribeError {
    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
        error_chain_fmt(self, f)
    }
}

impl ResponseError for SubscribeError {
    fn status_code(&self) -> StatusCode {
        match self {
            SubscribeError::ValidationError(_) => StatusCode::BAD_REQUEST,
            _ => StatusCode::INTERNAL_SERVER_ERROR,
        }
    }
}
```

Deriving `thiserror::Error` basically handles deriving the `std::error::Error` trait for us. Using the `#[error(...)]` macro for each enum variant handles deriving the `Display` trait for that variant. `#[source]` within the variant handles deriving the `source` method. `#[from]` derives the `From<T>` trait and the `source` method. Note that, as before, we don't derive `From` for sqlx errors because we need to disambiguate at a higher resolution than just the type.

## Using anyhow

Then we did one more round of refactoring. The problem being solved is that the `SubscribeError` was exposing a lot of unactionable info to the user. A user of the API can't change their behavior based on, say, an `InsertSubscriberError` vs. a `SendEmailError`. There's a good hint that this is the case: the `ResponseError::status_code` implementation. We're bundling everything except `ValidationError` into a `500` response. This suggests there's nothing the user can do.

So we refactored:
```rs
#[derive(thiserror::Error)]
pub enum SubscribeError {
    #[error("{0}")]
    ValidationError(String),
    #[error(transparent)]
    UnexpectedError(#[from] anyhow::Error), // can now convert from anything that implements Error
}
```

This is a better abstraction: we have one error type the user can do something about, and then a number of unexpected errors that they can't. The enum variant `UnexpectedError` which derives `From` for `anyhow::Error` lets us convert anything that implements `std::err::Error` into `UnexpectedError`. Among other things, `anyhow::Error` is basically a wrapper around `Box<dyn std::err::Error>`, enabling the dynamic dispatch needed to convert lots of different discrete error types into `anyhow::Error`. It also provides a `context` method, which basically provides info needed to `Display` the error. It's used like so:
```rs
    store_token(&mut transaction, subscriber_id, &token)
        .await
        .context("Failed to store the confirmation token for a new subscriber.")?;
```
Note that calling `context` is _mandatory_`. Otherwise, the `?` operator can't convert from the underlying error type (e.g., `StoreTokenError` or `sqlx::Error`) and our custom type. The compiler error message isn't very clear on this, but I think it's because `anyhow` doesn't know how to implement `Display` if we don't provide a message via `context`.

All in all, this chapter was a great deep dive into not just the implementation details of how to handle errors in Rust, but also how to think about error reporting, the purpose errors serve (both to the end users of an application, the developers working on the application, and the application itself in the form of control flow), and how you should separate responsibilities via abstraction layers in your error types.