### PR TITLE
Ch9: Newsletter delivery

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,5 +1,23 @@
 {
   "db": "PostgreSQL",
+  "7b57e2776a245ba1602f638121550485e2219a6ccaaa62b5ec3e4683e33a3b5f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "email",
+          "ordinal": 0,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n        SELECT email\n        FROM subscriptions\n        WHERE status = 'confirmed'\n        "
+  },
   "9a94d270a1d718eee17cd0858f369849ead62832c87a5bae8a9f164af201a485": {
     "describe": {
       "columns": [],

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -3,6 +3,13 @@ use validator::validate_email;
 #[derive(Debug)]
 pub struct SubscriberEmail(String);
 
+impl std::fmt::Display for SubscriberEmail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Just forward to Display impl of wrapped String
+        self.0.fmt(f)
+    }
+}
+
 impl SubscriberEmail {
     pub fn parse(s: String) -> Result<Self, String> {
         if validate_email(&s) {

--- a/src/email_client.rs
+++ b/src/email_client.rs
@@ -34,7 +34,7 @@ impl EmailClient {
 
     pub async fn send_email(
         &self,
-        recipient: SubscriberEmail,
+        recipient: &SubscriberEmail,
         subject: &str,
         html_content: &str,
         text_content: &str,
@@ -157,7 +157,7 @@ mod tests {
 
         // Act
         let _ = email_client
-            .send_email(subscriber_email, &subject, &content, &content)
+            .send_email(&subscriber_email, &subject, &content, &content)
             .await;
 
         // Assert handled by Mock...expect(1)
@@ -182,7 +182,7 @@ mod tests {
 
         // act
         let result = email_client
-            .send_email(subscriber_email, &subject, &content, &content)
+            .send_email(&subscriber_email, &subject, &content, &content)
             .await;
 
         // assert
@@ -207,7 +207,7 @@ mod tests {
 
         // act
         let result = email_client
-            .send_email(subscriber_email, &subject, &content, &content)
+            .send_email(&subscriber_email, &subject, &content, &content)
             .await;
 
         // assert
@@ -233,7 +233,7 @@ mod tests {
 
         // act
         let result = email_client
-            .send_email(subscriber_email, &subject, &content, &content)
+            .send_email(&subscriber_email, &subject, &content, &content)
             .await;
 
         // assert

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,7 +1,9 @@
 mod health_check;
+mod newsletters;
 mod subscriptions;
 mod subscriptions_confirm;
 
 pub use health_check::*;
+pub use newsletters::*;
 pub use subscriptions::*;
 pub use subscriptions_confirm::*;

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,0 +1,5 @@
+use actix_web::HttpResponse;
+
+pub async fn publish_newsletter() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,4 +1,10 @@
-use actix_web::{web, HttpResponse};
+use crate::domain::SubscriberEmail;
+use crate::email_client::EmailClient;
+use crate::error_handling::error_chain_fmt;
+use actix_web::{web, HttpResponse, ResponseError};
+use anyhow::Context;
+use sqlx::PgPool;
+use std::fmt::{Debug, Formatter};
 
 #[derive(serde::Deserialize)]
 pub struct BodyData {
@@ -12,6 +18,74 @@ pub struct Content {
     text: String,
 }
 
-pub async fn publish_newsletter(body: web::Json<BodyData>) -> HttpResponse {
-    HttpResponse::Ok().finish()
+struct ConfirmedSubscriber {
+    email: SubscriberEmail,
+}
+
+#[derive(thiserror::Error)]
+pub enum PublishError {
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+impl Debug for PublishError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
+    }
+}
+
+impl ResponseError for PublishError {}
+
+pub async fn publish_newsletter(
+    body: web::Json<BodyData>,
+    pool: web::Data<PgPool>,
+    email_client: web::Data<EmailClient>,
+) -> Result<HttpResponse, PublishError> {
+    let confirmed_subscribers = get_confirmed_subscribers(&pool).await?;
+    for subscriber in confirmed_subscribers {
+        email_client
+            .send_email(
+                subscriber.email,
+                &body.title,
+                &body.content.html,
+                &body.content.text,
+                // `with_context` is lazy, unlike `context`; used when the message has a runtime cost, as here
+                // where format allocates on the heap; note that must bring `anyhow::Context` trait into scope to use
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to send newsletter issue to {}",
+                    subscriber.email.as_ref().to_string()
+                )
+            })?;
+    }
+    Ok(HttpResponse::Ok().finish())
+}
+
+/// Gets all confirmed subscribers
+#[tracing::instrument(name = "Get confirmed subscribers", skip(pool))]
+async fn get_confirmed_subscribers(
+    pool: &PgPool,
+) -> Result<Vec<ConfirmedSubscriber>, anyhow::Error> {
+    struct Row {
+        email: String,
+    }
+    let rows = sqlx::query_as!(
+        Row,
+        r#"
+        SELECT email
+        FROM subscriptions
+        WHERE status = 'confirmed'
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+    let confirmed_subscribers = rows
+        .into_iter()
+        .map(|row| ConfirmedSubscriber {
+            email: SubscriberEmail::parse(row.email).unwrap(),
+        })
+        .collect();
+    Ok(confirmed_subscribers)
 }

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,5 +1,17 @@
-use actix_web::HttpResponse;
+use actix_web::{web, HttpResponse};
 
-pub async fn publish_newsletter() -> HttpResponse {
+#[derive(serde::Deserialize)]
+pub struct BodyData {
+    title: String,
+    content: Content,
+}
+
+#[derive(serde::Deserialize)]
+pub struct Content {
+    html: String,
+    text: String,
+}
+
+pub async fn publish_newsletter(body: web::Json<BodyData>) -> HttpResponse {
     HttpResponse::Ok().finish()
 }

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -78,11 +78,7 @@ pub async fn publish_newsletter(
 async fn get_confirmed_subscribers(
     pool: &PgPool,
 ) -> Result<Vec<Result<ConfirmedSubscriber, anyhow::Error>>, anyhow::Error> {
-    struct Row {
-        email: String,
-    }
-    let rows = sqlx::query_as!(
-        Row,
+    let rows = sqlx::query!(
         r#"
         SELECT email
         FROM subscriptions

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -134,7 +134,7 @@ pub async fn send_confirmation_email(
     );
     email_client
         .send_email(
-            new_subscriber.email,
+            &new_subscriber.email,
             "Welcome!",
             &format!(
                 "Welcome to our newsletter!<br />\

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -8,7 +8,7 @@ use tracing_actix_web::TracingLogger;
 
 use crate::configuration::{DatabaseSettings, Settings};
 use crate::email_client::EmailClient;
-use crate::routes::{confirm, health_check, subscribe};
+use crate::routes::{confirm, health_check, publish_newsletter, subscribe};
 
 /// Holds the running server and its port
 pub struct Application {
@@ -82,6 +82,7 @@ fn run(
             .route("/health_check", web::get().to(health_check))
             .route("/subscriptions", web::post().to(subscribe))
             .route("/subscriptions/confirm", web::get().to(confirm))
+            .route("/newsletters", web::post().to(publish_newsletter))
             .app_data(connection_pool.clone())
             .app_data(email_client.clone())
             .app_data(base_url.clone())

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -45,6 +45,16 @@ impl TestApp {
             .expect("Failed to execute request")
     }
 
+    /// Posts the provided body to the newsletters endpoint
+    pub async fn post_newsletter(&self, body: serde_json::Value) -> reqwest::Response {
+        reqwest::Client::new()
+            .post(&format!("{}/newsletters", self.address))
+            .json(&body)
+            .send()
+            .await
+            .expect("Failed to execute request")
+    }
+
     /// Extracts confirmation links from mocked email API requests
     pub async fn get_confirmation_links(
         &self,

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,4 +1,5 @@
 mod health_check;
 mod helpers;
+mod newsletter;
 mod subscriptions;
 mod subscriptions_confirm;

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -22,12 +22,7 @@ async fn newsletters_are_not_delivered_to_unconfirmed_subscirbers() {
             "html": "<p>HTML newsletter</p>"
         }
     });
-    let response = reqwest::Client::new()
-        .post(&format!("{}/newsletters", &app.address))
-        .json(&newsletter_request_body)
-        .send()
-        .await
-        .expect("Failed to execute request");
+    let response = app.post_newsletter(newsletter_request_body).await;
 
     // assert
     assert_eq!(response.status().as_u16(), 200);
@@ -53,12 +48,7 @@ async fn newsletters_are_delivered_to_confirmed_subscirbers() {
             "html": "<p>HTML newsletter</p>"
         }
     });
-    let response = reqwest::Client::new()
-        .post(&format!("{}/newsletters", &app.address))
-        .json(&newsletter_request_body)
-        .send()
-        .await
-        .expect("Failed to execute request");
+    let response = app.post_newsletter(newsletter_request_body).await;
 
     // assert
     assert_eq!(response.status().as_u16(), 200);
@@ -83,12 +73,7 @@ async fn newsletters_returns_400_for_invalid_data() {
 
     for (invalid_body, error_message) in test_cases {
         // act
-        let response = reqwest::Client::new()
-            .post(&format!("{}/newsletters", app.address))
-            .json(&invalid_body)
-            .send()
-            .await
-            .expect("Failed to execute request");
+        let response = app.post_newsletter(invalid_body).await;
 
         // assert
         assert_eq!(

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -1,0 +1,55 @@
+use crate::helpers::{spawn_app, TestApp};
+use wiremock::matchers::{any, method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+#[tokio::test]
+async fn newsletters_are_not_delivered_to_unconfirmed_subscirbers() {
+    // arrange
+    let app = spawn_app().await;
+    create_unconfirmed_subscriber(&app).await;
+
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&app.email_server)
+        .await;
+
+    // act
+    let newsletter_request_body = serde_json::json!({
+        "title": "Newsletter title",
+        "content": {
+            "text": "Plaintext newsletter",
+            "html": "<p>HTML newsletter</p>"
+        }
+    });
+    let response = reqwest::Client::new()
+        .post(&format!("{}/newsletters", &app.address))
+        .json(&newsletter_request_body)
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // assert
+    assert_eq!(response.status().as_u16(), 200);
+}
+
+/// Using the public API of app under test to create unconfirmed subscriber
+async fn create_unconfirmed_subscriber(app: &TestApp) {
+    let body = "name=test&email=test%40email.com";
+
+    // by using mount_as_scoped here, this mock is only active while the returned MockGuard is in scope
+    // i.e., this mock stops working once we leave `create_unconfirmed_subscriber`;
+    // this is important, as the mock in `newsletters_are_not_delivered_to_unconfirmed_subscribers` overlaps
+    // with this mock
+    let _mock_guard = Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .named("Create unconfirmed subscriber")
+        .expect(1)
+        .mount_as_scoped(&app.email_server)
+        .await;
+    app.post_subscriptions(body.to_string())
+        .await
+        .error_for_status()
+        .unwrap();
+}

--- a/tests/api/newsletter.rs
+++ b/tests/api/newsletter.rs
@@ -1,4 +1,4 @@
-use crate::helpers::{spawn_app, TestApp};
+use crate::helpers::{spawn_app, ConfirmationLinks, TestApp};
 use wiremock::matchers::{any, method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -33,8 +33,39 @@ async fn newsletters_are_not_delivered_to_unconfirmed_subscirbers() {
     assert_eq!(response.status().as_u16(), 200);
 }
 
+#[tokio::test]
+async fn newsletters_are_delivered_to_confirmed_subscirbers() {
+    // arrange
+    let app = spawn_app().await;
+    create_confirmed_subscriber(&app).await;
+
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&app.email_server)
+        .await;
+
+    // act
+    let newsletter_request_body = serde_json::json!({
+        "title": "Newsletter title",
+        "content": {
+            "text": "Plaintext newsletter",
+            "html": "<p>HTML newsletter</p>"
+        }
+    });
+    let response = reqwest::Client::new()
+        .post(&format!("{}/newsletters", &app.address))
+        .json(&newsletter_request_body)
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // assert
+    assert_eq!(response.status().as_u16(), 200);
+}
+
 /// Using the public API of app under test to create unconfirmed subscriber
-async fn create_unconfirmed_subscriber(app: &TestApp) {
+async fn create_unconfirmed_subscriber(app: &TestApp) -> ConfirmationLinks {
     let body = "name=test&email=test%40email.com";
 
     // by using mount_as_scoped here, this mock is only active while the returned MockGuard is in scope
@@ -50,6 +81,24 @@ async fn create_unconfirmed_subscriber(app: &TestApp) {
         .await;
     app.post_subscriptions(body.to_string())
         .await
+        .error_for_status()
+        .unwrap();
+
+    let email_request = &app
+        .email_server
+        .received_requests()
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    app.get_confirmation_links(email_request).await
+}
+
+async fn create_confirmed_subscriber(app: &TestApp) {
+    let confirmation_links = create_unconfirmed_subscriber(app).await;
+    reqwest::get(confirmation_links.html)
+        .await
+        .unwrap()
         .error_for_status()
         .unwrap();
 }


### PR DESCRIPTION
## About separation of concerns between fatal and non-fatal error handling

Discussion of this [blog post](http://sled.rs/errors.html), which was linked in the book. The idea concerns who is responsible for handling a particular error or class of errors. Say we have some error types that are fatal and require basically shutting down the system. Other types (call them local errors) need to be handled by a caller in some way. It is a mistake to lump these together in a single error enum (either directly or through overzealous `From` impls). 

The problem emerges when we start propagating errors up the call stack with `?`. If we coalesce all error types into a global error enum, then it's not obvious whether a caller should try to handle an error type or just propagate it. This allows patterns where handle-able errors (like validation errors) might accidentally go unhandled and get propagated up the call stack to shut down the entire application. 

A better pattern is to separate fatal and non-fatal errors into different types and then layer `Result`s to force callers to handle them differently. e.g.
``` rs
/// failable_operation can fail in two ways: one is fatal and requires 
/// human intervention. The other failure state can be handled programmatically
fn failable_operation() -> Result<Result<(), NonFatalError>, FatalError>

fn some_caller() Result<(), FatalError> {
  // then we call it like so
  let failable_result = failable_operation()?; // FatalError gets propagated

  // now we must explicitly handle NonFatalError
  // it cannot propagate because of `some_caller`'s return type and the fact
  // that we don't implement From<NonFatalError> for FatalError
  if let Err(error) = failable_result {
    // handle the expected issue
  }
}
```
This pattern makes it much harder to accidentally write code that treats a handleable, non-fatal error as a fatal error and blow up the whole program.